### PR TITLE
Menhaden landings update

### DIFF
--- a/R/comdat.R
+++ b/R/comdat.R
@@ -396,8 +396,6 @@ create_comdat <- function(comdat_path,
     tibble::as_tibble()
   
   if (!is.null(outputPathDataSets)) {
-    # make sure the directory exists
-    dir.create(outputPathDataSets, recursive = TRUE, showWarnings = FALSE)
     saveRDS(comdat, file.path(outputPathDataSets, "comdat.rds"))
   }
   

--- a/R/comdat.R
+++ b/R/comdat.R
@@ -396,6 +396,8 @@ create_comdat <- function(comdat_path,
     tibble::as_tibble()
   
   if (!is.null(outputPathDataSets)) {
+    # make sure the directory exists
+    dir.create(outputPathDataSets, recursive = TRUE, showWarnings = FALSE)
     saveRDS(comdat, file.path(outputPathDataSets, "comdat.rds"))
   }
   

--- a/data-raw/create_menhaden_input.R
+++ b/data-raw/create_menhaden_input.R
@@ -30,7 +30,7 @@ library(dplyr)
 file1 <- "/home/mgrezlik/EDAB_Datasets/AM Landings by Gaichas Regions 1967-2024.xlsx" #for workflow
 
 reduction <- read_excel(path = file1,
-                        range = "A7:F64")   # HARDCODED RANGE NEED TO UPDATE EACH YEAR
+                        range = "A7:F65")   # HARDCODED RANGE NEED TO UPDATE EACH YEAR
 
 reductiontons <- reduction[,c(1, 5:6)]
 names(reductiontons) <- c("year", "MAB", "GOM")
@@ -326,7 +326,7 @@ ggplot2::ggplot(menhadencatch, ggplot2::aes(x = year, y=NEUScatch)) +
 menhadenEOF <- menhadencatch  |> 
   dplyr::select(year, NEUScatch, MABcatch, GOMcatch, units)
 
-saveRDS(menhadenEOF,"/home/mgrezlik/EDAB_Dev/grezlik/menhadenEOF.rds")
+saveRDS(menhadenEOF,"/home/mgrezlik/EDAB_Datasets/Workflows/menhadenEOF.rds")
 
 
 # This R data object will be transferred securely to Andy Beet for incorporation into the Ecosystem Overfishing indicators.

--- a/data-raw/test_run_comdat.R
+++ b/data-raw/test_run_comdat.R
@@ -1,0 +1,182 @@
+# dir.create(here::here("data-raw/temp"))
+
+comdat_path <- '~/EDAB_Datasets/Workflows/commercial_comdat.rds'
+input_path_species <- "~/EDAB_Datasets/Workflows/SOE_species_list_24.rds"
+menhaden_path <- "~/EDAB_Datasets/Workflows/menhadenEOF.rds"
+outputPathDataSets <- "~/EDAB_Indicators"
+
+source(here::here("data-raw/workflow_comdat.R"))
+
+workflow_comdat(comdat_path = comdat_path,
+                  input_path_species = input_path_species,
+                  menhaden_path = menhaden_path,
+                  outputPathDataSets = outputPathDataSets)
+
+# compare to ecodata::comdat
+
+new_comdat <- workflow_comdat(comdat_path = comdat_path,
+                                   input_path_species = input_path_species,
+                                   menhaden_path = menhaden_path,
+                                   outputPathDataSets = outputPathDataSets)
+
+new_comdat <- new_comdat |> 
+                  dplyr::mutate(source = 'workflow')
+
+old_comdat <- ecodata::comdat |> 
+                  dplyr::mutate(source = 'ecodata')
+
+comdat_compare <- dplyr::bind_rows(new_comdat, old_comdat)
+
+library(stringr)
+library(dplyr)
+library(ggplot2)
+library(ecodata)
+
+
+# Filter for relevant variables, keeping the source distinct
+total_landings <- comdat_compare |>
+  dplyr::filter(
+    str_detect(Var, "Landings"),
+    !str_detect(Var, "Seafood|US only"), # Exclude seafood-only and US-only aggregates
+    Time >= 1982
+  ) |>
+  dplyr::mutate(
+    feeding.guild = str_extract(Var, "^\\w+"),
+    grouping = "Total"
+  )
+
+setup <- ecodata::plot_setup(shadedRegion = NULL, report = 'MidAtlantic')
+
+managed_landings <- comdat_compare |>
+  dplyr::filter(
+    str_detect(Var, "managed species - Landings"),
+    !str_detect(Var, "US only"),
+    Time >= 1982,
+    str_detect(Var, paste0("JOINT|", setup$council_abbr))
+  ) |>
+  dplyr::mutate(
+    feeding.guild = str_extract(Var, "^\\w+"),
+    grouping = "Council Managed"
+  )
+
+# Prepare data for the "guild" plot
+guilddat <- dplyr::bind_rows(total_landings, managed_landings) |>
+  dplyr::filter(!feeding.guild %in% c("Apex", "Other", "Landings")) |>
+  dplyr::group_by(Time, EPU, source, feeding.guild, grouping) |>
+  dplyr::summarise(Value = sum(Value, na.rm = TRUE), .groups = "drop") |>
+  dplyr::mutate(feeding.guild = factor(feeding.guild, levels = setup$feeding.guilds))
+
+
+plot_guild_landings <- guilddat |>
+  ggplot(aes(x = Time, y = Value, color = source, linetype = grouping)) +
+  geom_line(linewidth = setup$lwd) +
+  facet_grid(feeding.guild ~ EPU, scales = "free_y")
+
+
+
+# Prepare data for the "total" plot
+totdat <- guilddat |>
+  dplyr::group_by(Time, EPU, source, grouping) |>
+  dplyr::summarise(Value = sum(Value, na.rm = TRUE) / 1000, .groups = "drop") |>
+  dplyr::rename(Var = grouping)
+
+plot_total_landings <- totdat |>
+  ggplot(aes(x = Time, y = Value, color = source, linetype = Var)) +
+  geom_line(linewidth = setup$lwd) +
+  geom_point(aes(shape = Var), size = setup$pcex) +
+  facet_wrap(~EPU, scales = "free_y")
+
+land_ylabdat <- expression("Landings (10"^3 * " metric tons)")
+
+## DATA WRANGLING FOR REVENUE ----
+
+# Filter for relevant variables, keeping the source distinct
+total_revenue <- comdat_compare |>
+  dplyr::filter(
+    str_detect(Var, "Revenue"),
+    !str_detect(Var, "managed|US only"),
+    Time >= 1982
+  ) |>
+  dplyr::mutate(
+    feeding.guild = str_extract(Var, "^\\w+"),
+    grouping = "Total"
+  )
+
+managed_revenue <- comdat_compare |>
+  dplyr::filter(
+    str_detect(Var, "managed species - Revenue"),
+    !str_detect(Var, "US only"),
+    Time >= 1982,
+    str_detect(Var, paste0("JOINT|", setup$council_abbr))
+  ) |>
+  dplyr::mutate(
+    feeding.guild = str_extract(Var, "^\\w+"),
+    grouping = "Council Managed"
+  )
+
+# Prepare data for the "guild" plot
+guilddat <- bind_rows(total_revenue, managed_revenue) |>
+  dplyr::filter(!feeding.guild %in% c("Apex", "Other", "Revenue")) |>
+  dplyr::group_by(Time, EPU, source, feeding.guild, grouping) |>
+  dplyr::summarise(Value = sum(Value, na.rm = TRUE) / 1000, .groups = "drop") |>
+  dplyr::mutate(feeding.guild = factor(feeding.guild, levels = setup$feeding.guilds))
+
+plot_guild_revenue <- guilddat |>
+  ggplot(aes(x = Time, y = Value, color = source, linetype = grouping)) +
+  geom_line(linewidth = setup$lwd) +
+  facet_grid(feeding.guild ~ EPU, scales = "free_y")
+
+# Prepare data for the "total" plot
+totdat <- guilddat |>
+  dplyr::group_by(Time, EPU, source, grouping) |>
+  dplyr::summarise(Value = sum(Value, na.rm = TRUE) / 1000, .groups = "drop") |>
+  dplyr::rename(Var = grouping)
+
+rev_ylabdat <- expression("Revenue (10"^6 * " USD)")
+
+plot_total_revenue <- totdat |>
+  ggplot(aes(x = Time, y = Value, color = source, linetype = Var)) +
+  geom_line(linewidth = setup$lwd) +
+  geom_point(aes(shape = Var), size = setup$pcex) +
+  facet_wrap(~EPU, scales = "free_y")
+
+## PLOTTING ----
+
+# Apply common aesthetics
+p_tot_rev <- plot_total_revenue +
+  scale_x_continuous(breaks = seq(1980, 2020, by = 10), expand = c(0.01, 0.01)) +
+  labs(y = rev_ylabdat, x = NULL) +
+  ecodata::theme_ts() +
+  ecodata::theme_title() +
+  ecodata::theme_facet() +
+  theme(legend.position = "bottom", legend.title = element_blank())
+
+p_guild_rev <- plot_guild_revenue +
+  scale_x_continuous(breaks = seq(1980, 2020, by = 10), expand = c(0.01, 0.01)) +
+  labs(y = rev_ylabdat, x = NULL) +
+  ecodata::theme_ts() +
+  ecodata::theme_title() +
+  ecodata::theme_facet() +
+  theme(legend.position = "bottom", legend.title = element_blank())
+
+p_tot_land <- plot_total_landings +
+  scale_x_continuous(breaks = seq(1980, 2020, by = 10), expand = c(0.01, 0.01)) +
+  labs(y = land_ylabdat, x = NULL) +
+  ecodata::theme_ts() +
+  ecodata::theme_title() +
+  ecodata::theme_facet() +
+  theme(legend.position = "bottom", legend.title = element_blank())
+
+p_guild_land <- plot_guild_landings +
+  scale_x_continuous(breaks = seq(1980, 2020, by = 10), expand = c(0.01, 0.01)) +
+  labs(y = land_ylabdat, x = NULL) +
+  ecodata::theme_ts() +
+  ecodata::theme_title() +
+  ecodata::theme_facet() +
+  theme(legend.position = "bottom", legend.title = element_blank())
+
+# look at plots
+p_tot_rev
+p_guild_rev
+p_tot_land
+p_guild_land


### PR DESCRIPTION
Updating menhaden landings to go through 2024.

Changes made:
### data-raw

**create_menhaden_input.R**

- changed manual section that selects data years in excel to include 2024
- saved to EDAB_Datasets/Workflows instead of EDAB_Dev as we had been doing back when I started on this indicator


**test_run_comdat.R**
I created this file from old script in my personal test run file to make it easier on reviewers. This script:
- sets input and output paths
- runs the workflow and saves to EDAB_Datasets/Workflows
- graphically compares the workflow-generated indicator to ecodata::comdat