### PR TITLE
Fix Windowpane Jurisdiction in productivity_anomaly

### DIFF
--- a/R/productivity_anomaly.R
+++ b/R/productivity_anomaly.R
@@ -836,7 +836,8 @@ productivity_anomaly<- rbind(productivity_anomaly1, prod_assess1)
 
 species_groupings <- ecodata::species_groupings |> 
                           dplyr::select(COMNAME,Fed.Managed) |> 
-                          unique()
+                          unique() |> 
+                          dplyr::mutate(Fed.Managed = replace(Fed.Managed, COMNAME == "WINDOWPANE", "NEFMC"))
 
 ## Create clean species column to match with ---------------
 


### PR DESCRIPTION
Added a line to change Fed.Managed value for Windowpane from 'NA' to 'NEFMC'. This column is then used to populate the Jurisdiction column in the final productivity_anomaly product.

Next year we will want to make this change to ecodata::get_species_groupings on the main branch of that repo.