### PR TITLE
Feature(#73): `comdat` indicator compositional data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/comdat.R
+++ b/R/comdat.R
@@ -37,25 +37,9 @@ create_comdat <- function(
     )
   }
 
-  # 1. Define EPU Areas ----
-  # Define each EPU area as a tibble
-  gom <- tibble::tibble(AREA = c(500, 510, 512:515), EPU = "GOM")
-  gb <- tibble::tibble(AREA = c(521:526, 551, 552, 561, 562), EPU = "GB")
-  mab <- tibble::tibble(
-    AREA = c(537, 539, 600, 612:616, 621, 622, 625, 626, 631, 632),
-    EPU = "MAB"
-  )
-  ss <- tibble::tibble(AREA = c(463:467, 511), EPU = "SS")
-
-  # Combine all into one tibble
-  epuAreas <- dplyr::bind_rows(gom, gb, mab, ss) |>
-    dplyr::mutate(
-      NESPP3 = 1,
-      MeanProp = 1
-    )
-
   # 2. Load and Process All Data Sources ----
   comland_list <- readRDS(comdat_path)
+  # Remove menhaden(221) and esastern oyster(789)
   comland_raw <- comland_list$comland |>
     tibble::as_tibble() |>
     dplyr::filter(NESPP3 != 221, NESPP3 != 789)
@@ -107,6 +91,8 @@ create_comdat <- function(
     dplyr::distinct()
 
   # 3. Combine and Clean Base Data ----
+  # Convert scallop live to landed weight for foreign landings to match up with
+  # landed weights of comlandr pull
   comland.agg <- dplyr::bind_rows(comland_raw, menhaden_data) |>
     dplyr::mutate(NESPP3 = as.numeric(NESPP3)) |>
     dplyr::left_join(species_codes, by = "NESPP3") |>
@@ -118,6 +104,13 @@ create_comdat <- function(
 
   # 4. Landings section from create_comdat ----------
   # Not adding NAFO landings like was done previously
+  species_contrib <- comland.agg |>
+    dplyr::group_by(YEAR, EPU, NESPP3, US, UTILCD, SOE.24, Fed.Managed) |>
+    dplyr::summarise(
+      V1 = sum(SPPLIVMT, na.rm = TRUE),
+      V2 = sum(SPPVALUE, na.rm = TRUE),
+      .groups = "drop"
+    )
 
   # Summarize comland.agg landings
   landings <- comland.agg |>
@@ -434,9 +427,5 @@ create_comdat <- function(
     dplyr::arrange(Var, Time) |>
     tibble::as_tibble()
 
-  if (!is.null(outputPathDataSets)) {
-    saveRDS(comdat, file.path(outputPathDataSets, "comdat.rds"))
-  }
-
-  return(comdat)
+  return(list(comdat = comdat, comdat_species = species_contrib))
 }

--- a/R/comdat.R
+++ b/R/comdat.R
@@ -107,8 +107,8 @@ create_comdat <- function(
   species_contrib <- comland.agg |>
     dplyr::group_by(YEAR, EPU, NESPP3, US, UTILCD, SOE.24, Fed.Managed) |>
     dplyr::summarise(
-      V1 = sum(SPPLIVMT, na.rm = TRUE),
-      V2 = sum(SPPVALUE, na.rm = TRUE),
+      SPPLIVMT = sum(SPPLIVMT, na.rm = TRUE),
+      SPPVALUE = sum(SPPVALUE, na.rm = TRUE),
       .groups = "drop"
     )
 

--- a/R/comdat.R
+++ b/R/comdat.R
@@ -8,7 +8,9 @@
 #' @param menhaden_path Character string. Path to the menhaden data output by data-raw/create_menhaden_input.R
 #' @param outputPathDataSets Character string. Path to folder where data pull should be saved
 #'
-#' @return A single tibble containing all summarized commercial data.
+#' @return list
+#' \item{comdat}{`ecodata::comdat` data frame}
+#' \item{comdat_species}{species data used to create the `comdat` indicator}
 #'
 #'
 #' @importFrom dplyr bind_rows case_when distinct filter group_by left_join mutate rename select summarise tribble

--- a/data-raw/workflow_comdat.R
+++ b/data-raw/workflow_comdat.R
@@ -30,7 +30,7 @@ workflow_comdat <- function(
   comdat_path,
   input_path_species,
   menhaden_path,
-  outputPathDataSets
+  outputPath
 ) {
   # Add check to skip running workflow if data not present
 
@@ -38,7 +38,7 @@ workflow_comdat <- function(
     {
       if (
         !all(
-          !is.null(outputPathDataSets),
+          !is.null(outputPath),
           file.exists(comdat_path),
           file.exists(input_path_species),
           file.exists(menhaden_path)
@@ -52,9 +52,14 @@ workflow_comdat <- function(
         comdat_path = comdat_path,
         input_path_species = input_path_species,
         menhaden_path = menhaden_path,
-        outputPathDataSets = outputPathDataSets
+        outputPathDataSets = outputPath
       )
 
+      saveRDS(indicatorData$comdat, paste0(outputPath, "/comdat.rds"))
+      saveRDS(
+        indicatorData$comdat_species,
+        paste0(outputPath, "/comdat_species.rds")
+      )
       return(indicatorData)
     },
     error = function(e) {

--- a/data-raw/workflow_comdat.R
+++ b/data-raw/workflow_comdat.R
@@ -4,10 +4,12 @@
 #'
 #' @param comdat_path Character string. Full path to the commercial data rds file for comdat indicator
 #' @param input_path_species Character string. Full path to the species list data pull rds file
-#' @param outputPathDataSets Character string. Path to folder where data pull should be saved
+#' @param outputPath Character string. Path to folder where data pull should be saved
 #' @param menhaden_path Character string. Full path to the menhaden data .rds file
 #'
-#' @return ecodata::comdat data frame
+#' @return list
+#' \item{comdat}{`ecodata::comdat` data frame}
+#' \item{comdat_species}{species data used to create the `comdat` indicator}
 #'
 #' @example
 #' \dontrun{

--- a/data-raw/workflow_comdat.R
+++ b/data-raw/workflow_comdat.R
@@ -17,7 +17,7 @@
 #'    comdat_path = "path/to/commerical_comdat.rds",
 #'    input_path_species = "path/to/species/data/.rds",
 #'    menhaden_path = "path/to/menhaden/data/.rds",
-#'    outputPathDataSets = "path/to/output/folder"
+#'    outputPath = "path/to/output/folder"
 #'    )
 #' }
 #'

--- a/man/create_comdat.Rd
+++ b/man/create_comdat.Rd
@@ -21,7 +21,9 @@ create_comdat(
 \item{outputPathDataSets}{Character string. Path to folder where data pull should be saved}
 }
 \value{
-A single tibble containing all summarized commercial data.
+list
+\item{comdat}{\code{ecodata::comdat} data frame}
+\item{comdat_species}{species data used to create the \code{comdat} indicator}
 }
 \description{
 Processes and combines commercial landings and Menhaden data to produce a


### PR DESCRIPTION
Your commits explain the `who`, `what`, `where` and `when` of these changes. Your code shows the `how`. You do not need to reiterate this. This PR should complete the picture by explaining `why` these changes are necessary.
Please complete the fields below, replacing or removing placeholder text where necessary:

### Justification

Aggregate indicators (`comdat`) lack the granularity to determine which species, if any, are driving the group. There is a need to examine the composition of the aggregate. An additional species level data set is output for use in diagnostics plots to help support the SOE reporting process

Fixes #73 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Rebuild package from this branch, then source and run the `data-raw/workflow_comdat.r`. An additional rds (`comdat_species.rds`) file should be produced and written to the directory specified by the `outputPath`. The fields of this new data set are YEAR, EPU, NESPP3, US, UTILCD, SOE.24, Fed.Managed, SPPLTMT, and SPPVALUE, where SOE.24 is the guild assigned to species


### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
