### PR TITLE
Feature(#74):  `aggregate biomass` compositional data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/aggregate_biomass.r
+++ b/R/aggregate_biomass.r
@@ -15,7 +15,10 @@
 #' }
 #'
 #'
-#' @return `ecodata::aggregate_biomass` data frame
+#' @return list
+#' \item{aggregate_biomass}{The `ecodata::aggregate_biomass` data frame}
+#' \item{aggregate_biomass_species}{Stratified mean for each species/Season at EPU level that make up the aggregate}
+#'
 #'
 #' @export
 
@@ -37,11 +40,14 @@ create_aggregate_biomass <- function(inputPathSurvey, inputPathSpecies) {
   )
 
   # Combine the two data frames
-  combined_data <- rbind(epubio, shelfbio) |>
+  combined_data <- rbind(epubio$aggregate_biomass_epu, shelfbio) |>
     dplyr::as_tibble() |>
     dplyr::relocate(Time, Var, Value, EPU, Units)
 
-  return(combined_data)
+  return(list(
+    aggregate_biomass = combined_data,
+    aggregate_biomass_species = epubio$aggregate_biomass_species
+  ))
 }
 
 
@@ -62,7 +68,9 @@ create_aggregate_biomass <- function(inputPathSurvey, inputPathSpecies) {
 #'
 #' }
 #'
-#' @return data frame
+#' @return list
+#' \item{aggregate_biomass_epu}{stratified means for EPU, at council, nearshore/offshore level }
+#' \item{aggregate_biomass_species}{stratified mean for each species/Season at EPU level}
 #'
 #' @noRd
 
@@ -114,6 +122,7 @@ create_aggregate_biomass_epu <- function(
   SS <- c(1300:1352, 3840:3990)
 
   survey.data <- c()
+  aggregate_biomass_species <- NULL
 
   for (iepu in 1:length(EPU)) {
     epu.strata <- get(EPU[iepu])
@@ -121,7 +130,20 @@ create_aggregate_biomass_epu <- function(
     epu.inshore <- epu.strata[which(epu.strata >= 2000)]
     epu.offshore <- epu.strata[which(epu.strata < 2000)]
 
+    message(paste0("EPU = ", EPU[iepu], ". SVSPP stratified means"))
+    # calculate species specific stratified means
+    species <- survdat::calc_stratified_mean(
+      survdat,
+      filterByArea = epu.strata,
+      filterBySeason = c('Fall', 'Spring'),
+      groupDescription = 'SVSPP',
+      tidy = T
+    ) |>
+      dplyr::mutate(EPU = EPU[iepu])
+    aggregate_biomass_species <- rbind(aggregate_biomass_species, species)
+
     #Calculate stratified means
+    message(paste0("EPU = ", EPU[iepu], ". Guild stratified means"))
     all <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.strata,
@@ -129,6 +151,7 @@ create_aggregate_biomass_epu <- function(
       groupDescription = 'SOE.24',
       tidy = T
     )
+    message(paste0("EPU = ", EPU[iepu], ". FMC stratified means"))
     all.fmc <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.strata,
@@ -136,6 +159,8 @@ create_aggregate_biomass_epu <- function(
       groupDescription = 'SOE.Managed',
       tidy = T
     )
+
+    message(paste0("EPU = ", EPU[iepu], "(Inshore). Guild stratified means"))
     inshore.all <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.inshore,
@@ -143,6 +168,7 @@ create_aggregate_biomass_epu <- function(
       groupDescription = 'SOE.24',
       tidy = T
     )
+    message(paste0("EPU = ", EPU[iepu], "(Offshore). Guild stratified means"))
     offshore.all <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.offshore,
@@ -150,6 +176,8 @@ create_aggregate_biomass_epu <- function(
       groupDescription = 'SOE.24',
       tidy = T
     )
+    message(paste0("EPU = ", EPU[iepu], "(Inshore). FMC stratified means"))
+
     inshore.fmc <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.inshore,
@@ -157,6 +185,8 @@ create_aggregate_biomass_epu <- function(
       groupDescription = 'SOE.Managed',
       tidy = T
     )
+    message(paste0("EPU = ", EPU[iepu], "(Offshore). FMC stratified means"))
+
     offshore.fmc <- survdat::calc_stratified_mean(
       survdat,
       filterByArea = epu.offshore,
@@ -289,7 +319,10 @@ create_aggregate_biomass_epu <- function(
   survey.data <- expanded |>
     dplyr::left_join(survey.data, by = c("Time", "Var", "EPU"))
 
-  return(survey.data)
+  return(list(
+    aggregate_biomass_epu = survey.data,
+    aggregate_biomass_species = aggregate_biomass_species
+  ))
 }
 
 

--- a/data-raw/workflow_aggregate_biomass.R
+++ b/data-raw/workflow_aggregate_biomass.R
@@ -48,7 +48,14 @@ workflow_aggregate_biomass <- function(
       )
 
       # Write data to file
-      saveRDS(indicatorData, paste0(outputPath, "/aggregate_biomass.rds"))
+      saveRDS(
+        indicatorData$aggregate_biomass,
+        paste0(outputPath, "/aggregate_biomass.rds")
+      )
+      saveRDS(
+        indicatorData$aggregate_biomass_species,
+        paste0(outputPath, "/aggregate_biomass_species.rds")
+      )
       return(indicatorData)
     },
     error = function(e) {

--- a/data-raw/workflow_aggregate_biomass.R
+++ b/data-raw/workflow_aggregate_biomass.R
@@ -4,7 +4,11 @@
 #' @param inputPathSpecies Character string. Full path to the species list data pull rds file
 #' @param outputPath Character string. Path to folder where data pull should be saved
 #'
-#' @return Nothing. rds file exported
+#' @return List
+#'
+#' \item{aggregate_biomass}{The `ecodata::aggregate_biomass` data frame}
+#' \item{aggregate_biomass_species}{Stratified mean for each species/Season at EPU level that make up the aggregate}
+#'
 #'
 #' @section Dependencies:
 #'

--- a/man/create_aggregate_biomass.Rd
+++ b/man/create_aggregate_biomass.Rd
@@ -12,7 +12,9 @@ create_aggregate_biomass(inputPathSurvey, inputPathSpecies)
 \item{inputPathSpecies}{Character string. Full path to the species list data pull rds file}
 }
 \value{
-\code{ecodata::aggregate_biomass} data frame
+list
+\item{aggregate_biomass}{The \code{ecodata::aggregate_biomass} data frame}
+\item{aggregate_biomass_species}{Stratified mean for each species/Season at EPU level that make up the aggregate}
 }
 \description{
 This uses the survdat data pull from the survey package and creates EPU


### PR DESCRIPTION
### Justification

Aggregate indicators (`aggregate_biomass`  ) lacks the granularity to determine which species, if any, are driving the group. There is a need to examine the composition of the aggregate. An additional species level data set is output for use in diagnostics plots to help support the SOE reporting process

Fixes #74 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Rebuild package from this branch, then source and run the data-raw/workflow_aggregate_biomass.r. (You'll need to specify paths for the data files which is dependent on where you are running the script from). An additional rds (aggregate_biomass_species.rds) file should be produced and written to the directory specified by the outputPath. The fields of this new data set are YEAR, EPU, SVSPP, SEASON, VARIABLE, VALUE, UNITS

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
