### PR TITLE
Fix(#78): replaced internal function reference to external

### DIFF
--- a/R/exp_n.R
+++ b/R/exp_n.R
@@ -113,8 +113,8 @@ create_exp_n <- function(input_path_albatross, input_path_bigelow) {
     dsn = system.file("extdata", "EPU.shp", package = "survdat"),
     quiet = T
   )
-  ESn.al.sta <- survdat:::post_strat(al.station, EPU, "EPU")
-  ESn.big.sta <- survdat:::post_strat(big.station, EPU, "EPU")
+  ESn.al.sta <- survdat::post_strat(al.station, EPU, "EPU")
+  ESn.big.sta <- survdat::post_strat(big.station, EPU, "EPU")
 
   #calculate the mean ESn
   data.table::setkey(ESn.al.sta, YEAR, SEASON, EPU)

--- a/R/mass_inshore_survey.R
+++ b/R/mass_inshore_survey.R
@@ -88,7 +88,7 @@ create_mass_inshore_survey <- function(
   prepData[, S.Area := NULL]
 
   #Calculate stratified mean
-  stratmeanData <- survdat:::strat_mean(
+  stratmeanData <- survdat::strat_mean(
     prepData,
     groupDescription = 'SOE.24', ##### see how other scripts in workflow example handle terminal year hardcoding
     mergesexFlag = T,

--- a/R/survey_shannon.R
+++ b/R/survey_shannon.R
@@ -117,7 +117,7 @@ create_survey_shannon <- function(input_path_albatross, input_path_bigelow) {
     dsn = system.file("extdata", "EPU.shp", package = "survdat"),
     quiet = T
   )
-  stations.epu <- survdat:::post_strat(stations, EPU, "EPU")
+  stations.epu <- survdat::post_strat(stations, EPU, "EPU")
 
   #Calculate mean shannon index
   shannon.mean <- stations.epu[, mean(Shannon), by = c('YEAR', 'SEASON', 'EPU')]

--- a/data-raw/workflow_pull_recreational_data.R
+++ b/data-raw/workflow_pull_recreational_data.R
@@ -28,7 +28,7 @@ workflow_pull_recreational_data <- function(output_path_indicators = NULL) {
         rec_hms_data,
         paste0(output_path_indicators, "/hms_mrip_", Sys.Date(), ".rds")
       )
-      return(rc_hms_data)
+      return(rec_hms_data)
     },
     error = function(e) {
       message("An error occurred: ", conditionMessage(e))


### PR DESCRIPTION
### Justification

`survdat` had internal functions that were needed for data analysis outside of the package. These were made external functions in the `survdat` package. As a consequence all reference to them here needed to change from using `:::` to `::`. This PR makes these changes

Fixes #78 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Install `survdat` v2.0.0.
Running any one of the workflows that use `survdat` should be suffice, `exp_n`, `shannon_survey`, or `mass_inshore_survey`. For example `SOEWorkflows::create_mass_inshore_survey(input_path_mass_survey,  input_path_species)`. You can use the `example_test_runs.r` script as a template. Please don't commit additional example_test scripts, but keep them locally.

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
